### PR TITLE
(security) Phase 2 security hardening

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,13 @@
 import type { NextConfig } from 'next';
 
+// Fail fast if required env vars are missing
+const requiredEnvVars = ['MONGODB_URI', 'STEAM_API_KEY', 'STEAM_ID'];
+for (const key of requiredEnvVars) {
+  if (!process.env[key]) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+}
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [

--- a/src/app/api/leetcode/route.ts
+++ b/src/app/api/leetcode/route.ts
@@ -2,10 +2,20 @@ import { NextResponse } from 'next/server';
 import { request } from '@/api/axios';
 import { API_CONFIG, API_ERROR_MESSAGES, HTTP_STATUS } from '@/api/config';
 import type { NextRequest } from 'next/server';
+import { checkOrigin } from '@/lib/utils/checkOrigin';
 
 export async function POST(requestObj: NextRequest) {
+  const originError = checkOrigin(requestObj);
+  if (originError) return originError;
+
   try {
     const body = await requestObj.json();
+
+    // Whitelist: only allow our own stats query
+    if (typeof body?.query !== 'string' || !body.query.includes('matchedUser')) {
+      return NextResponse.json({ error: API_ERROR_MESSAGES.FORBIDDEN }, { status: HTTP_STATUS.FORBIDDEN });
+    }
+
     const data = await request.post(API_CONFIG.LEETCODE.BASE, body);
     return NextResponse.json(data);
   } catch (error) {

--- a/src/app/api/steam/achievements/[appid]/route.ts
+++ b/src/app/api/steam/achievements/[appid]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { SteamAPI } from '@/api/steam';
 import type { SteamAchievementSchema, SteamAchievement } from '@/lib/steam/types';
 import { API_ERROR_MESSAGES, HTTP_STATUS } from '@/api/config';
+import { checkOrigin } from '@/lib/utils/checkOrigin';
 
 const steamAPI = new SteamAPI();
 
@@ -9,6 +10,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ appid: string }> }
 ) {
+  const originError = checkOrigin(request);
+  if (originError) return originError;
+
   try {
     const { appid } = await params;
     const appidNum = parseInt(appid, 10);

--- a/src/app/api/steam/route.ts
+++ b/src/app/api/steam/route.ts
@@ -1,8 +1,11 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { SteamAPI } from '@/api/steam';
 import { API_ERROR_MESSAGES, HTTP_STATUS } from '@/api/config';
+import { checkOrigin } from '@/lib/utils/checkOrigin';
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const originError = checkOrigin(req);
+  if (originError) return originError;
   try {
     const steamAPI = new SteamAPI();
     const stats = await steamAPI.getUserStats();

--- a/src/lib/utils/checkOrigin.ts
+++ b/src/lib/utils/checkOrigin.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { HTTP_STATUS } from '@/api/config';
+
+const ALLOWED_ORIGINS = [
+  process.env.NEXT_PUBLIC_APP_URL,
+  'http://localhost:3000',
+  'http://localhost:3001',
+].filter(Boolean) as string[];
+
+/**
+ * Validates that the request originates from our own site.
+ * Returns a 403 NextResponse if rejected, or null if allowed.
+ *
+ * Rules:
+ *  - No Origin header → allowed (SSR / same-origin GET requests)
+ *  - Origin matches an allowed origin → allowed
+ *  - Otherwise → 403 Forbidden
+ */
+export function checkOrigin(req: NextRequest): NextResponse | null {
+  const origin = req.headers.get('origin');
+  if (!origin) return null; // server-side or same-origin
+
+  const isAllowed = ALLOWED_ORIGINS.some((allowed) => origin.startsWith(allowed));
+  if (isAllowed) return null;
+
+  return NextResponse.json({ error: 'Forbidden' }, { status: HTTP_STATUS.FORBIDDEN });
+}


### PR DESCRIPTION
- Add GraphQL query whitelist to /api/leetcode: reject requests missing 'matchedUser'
- Add startup env var validation in next.config.ts: fail fast on missing MONGODB_URI/STEAM_API_KEY/STEAM_ID
- Create checkOrigin() utility to validate Origin header on sensitive API routes
- Apply checkOrigin to /api/leetcode, /api/steam, /api/steam/achievements/[appid]