### PR TITLE
(fix) drop _id/__v from mongoose lean queries

### DIFF
--- a/src/lib/about/server.ts
+++ b/src/lib/about/server.ts
@@ -11,8 +11,8 @@ export async function getAboutData(): Promise<AboutData> {
   cacheTag('about');
   await dbConnect();
   const [skills, experiences] = await Promise.all([
-    Skills.find().lean() as unknown as Promise<RawSkillsData[]>,
-    Experiences.find().lean() as unknown as Promise<RawExperiencesData[]>,
+    Skills.find({}, { _id: 0, __v: 0 }).lean() as unknown as Promise<RawSkillsData[]>,
+    Experiences.find({}, { _id: 0, __v: 0 }).lean() as unknown as Promise<RawExperiencesData[]>,
   ]);
   return parseAboutData({ skills, experiences });
 }

--- a/src/lib/blog/server.ts
+++ b/src/lib/blog/server.ts
@@ -10,7 +10,9 @@ export async function getAllBlogs(): Promise<Record<Locale, Blog[]>> {
   cacheLife('hours');
   cacheTag('blogs');
   await dbConnect();
-  const blogs = (await BlogModel.find().sort({ date: -1 }).lean()) as unknown as Blog[];
+  const blogs = (await BlogModel.find({}, { _id: 0, __v: 0 })
+    .sort({ date: -1 })
+    .lean()) as unknown as Blog[];
   return parseBlogs(blogs);
 }
 
@@ -19,7 +21,7 @@ export async function getBlogBySlug(slug: string): Promise<Blog | null> {
   cacheLife('hours');
   cacheTag(`blog-${slug}`);
   await dbConnect();
-  return (await BlogModel.findOne({ slug }).lean()) as Blog | null;
+  return (await BlogModel.findOne({ slug }, { _id: 0, __v: 0 }).lean()) as Blog | null;
 }
 
 export async function getAllBlogSlugs() {

--- a/src/lib/blog/types.ts
+++ b/src/lib/blog/types.ts
@@ -1,5 +1,4 @@
 export interface Blog {
-  _id: string;
   slug: string;
   date: string;
   readTime: string;

--- a/src/lib/contact/server.ts
+++ b/src/lib/contact/server.ts
@@ -8,5 +8,5 @@ export async function getContactData(): Promise<ContactData | null> {
   cacheLife('hours');
   cacheTag('contact');
   await dbConnect();
-  return (await ContactModel.findOne().lean()) as ContactData | null;
+  return (await ContactModel.findOne({}, { _id: 0, __v: 0 }).lean()) as ContactData | null;
 }

--- a/src/lib/project/server.ts
+++ b/src/lib/project/server.ts
@@ -10,6 +10,8 @@ export async function getAllProjects(): Promise<Record<Locale, Project[]>> {
   cacheLife('hours');
   cacheTag('projects');
   await dbConnect();
-  const projects = (await ProjectModel.find().sort({ title: 1 }).lean()) as unknown as Project[];
+  const projects = (await ProjectModel.find({}, { _id: 0, __v: 0 })
+    .sort({ title: 1 })
+    .lean()) as unknown as Project[];
   return parseProjects(projects);
 }

--- a/src/lib/project/types.ts
+++ b/src/lib/project/types.ts
@@ -1,7 +1,6 @@
 import { Locale } from '@/i18n/types';
 
 export interface Project {
-  _id: string;
   title: string;
   description: string;
   tags: string[];


### PR DESCRIPTION
Mongoose .lean() returns ObjectId instances for _id, which have a toJSON method and trip the RSC "only plain objects can be passed to Client Components" warning when blog/projects/about/contact server data is forwarded as props.

Project _id along with __v out at the query level, and remove the (unused) _id field from the Blog and Project types.