### PR TITLE
(fix) normalize SITE_URL to handle bare hostnames in NEXT_PUBLIC_APP_URL

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,10 +12,9 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Analytics } from '@vercel/analytics/next';
 import { getTranslations } from '@/lib/translations/server';
 import en from '@/i18n/locales/en';
+import { SITE_URL } from '@/lib/constants/siteUrl';
 
 const inter = Inter({ subsets: ['latin'] });
-
-const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from 'next';
-
-const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+import { SITE_URL } from '@/lib/constants/siteUrl';
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,6 @@
 import type { MetadataRoute } from 'next';
 import { getAllBlogSlugs } from '@/lib/blog/server';
-
-const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+import { SITE_URL } from '@/lib/constants/siteUrl';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticRoutes: MetadataRoute.Sitemap = [

--- a/src/lib/constants/siteUrl.ts
+++ b/src/lib/constants/siteUrl.ts
@@ -1,0 +1,13 @@
+/**
+ * Normalized site URL with guaranteed protocol and no trailing slash.
+ *
+ * NEXT_PUBLIC_APP_URL may be set as a bare host (e.g. "zhupi222.top") in
+ * Vercel's env config. `new URL()` requires a protocol, so we prepend https://
+ * if missing.
+ */
+function normalize(raw: string): string {
+  const withProtocol = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  return withProtocol.replace(/\/+$/, '');
+}
+
+export const SITE_URL = normalize(process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000');


### PR DESCRIPTION
Vercel builds with NEXT_PUBLIC_APP_URL=zhupi222.top (no protocol) crashed in layout.tsx because new URL() requires a scheme. Centralize normalization in src/lib/constants/siteUrl.ts: prepend https:// when missing, strip trailing slashes. Reuse from layout, sitemap, and robots.

Reproduced locally with NEXT_PUBLIC_APP_URL=zhupi222.top pnpm run build → now passes.