### PR TITLE
Update portfolio branding to Strata

### DIFF
--- a/src/components/home/ProjectArtwork.test.tsx
+++ b/src/components/home/ProjectArtwork.test.tsx
@@ -20,9 +20,9 @@ describe('ProjectArtwork', () => {
     expect(artwork).not.toContain('Date system / 03');
   });
 
-  it('renders repository artwork for the Git Client project', () => {
+  it('renders repository artwork for the Strata project', () => {
     const artwork = renderToStaticMarkup(
-      <ProjectArtwork slug="git-client" order={-10} title="Git Client" />
+      <ProjectArtwork slug="git-client" order={-10} title="Strata" />
     );
 
     expect(artwork).toContain('Repository graph / 00');

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -36,9 +36,9 @@ const en: Translations = {
             'A configurable desktop system for capture, AI generation, payment, printing, and offline operation.',
         },
         {
-          title: 'Git Client',
+          title: 'Strata',
           description:
-            'A cross-platform Git client built with Tauri 2, React 19, and a layered Rust workspace.',
+            'A cross-platform desktop Git client with focused history, diffs, and everyday repository workflows.',
         },
         {
           title: 'Family Meal Planner',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -35,8 +35,8 @@ const zh: Translations = {
           description: '覆盖拍摄、AI 生成、支付、打印与离线运行的可配置桌面系统',
         },
         {
-          title: 'Git Client',
-          description: '基于 Tauri 2、React 19 与 Rust 分层工作区构建的跨平台 Git 客户端',
+          title: 'Strata',
+          description: '一款聚焦历史、Diff 与日常仓库操作的跨平台桌面 Git 客户端',
         },
         {
           title: '家庭食谱小程序',

--- a/src/lib/project/gitClientProject.test.ts
+++ b/src/lib/project/gitClientProject.test.ts
@@ -10,19 +10,13 @@ import {
 describe('GIT_CLIENT_PROJECT', () => {
   it('defines a public bilingual portfolio entry selected ahead of existing projects', () => {
     expect(GIT_CLIENT_PROJECT.slug).toBe('git-client');
-    expect(GIT_CLIENT_PROJECT.url).toBe(
-      'https://github.com/JadenFanZhupi222/git-client'
-    );
+    expect(GIT_CLIENT_PROJECT.url).toBe('https://github.com/JadenFanZhupi222/git-client');
     expect(GIT_CLIENT_PROJECT.order).toBe(-10);
-    expect(GIT_CLIENT_PROJECT.tags).toEqual([
-      'Tauri 2',
-      'Rust',
-      'React 19',
-      'TypeScript',
-      'Git',
-    ]);
+    expect(GIT_CLIENT_PROJECT.tags).toEqual(['Tauri 2', 'Rust', 'React 19', 'TypeScript', 'Git']);
     expect(GIT_CLIENT_PROJECT.locales.en.highlights).toHaveLength(4);
     expect(GIT_CLIENT_PROJECT.locales.zh.highlights).toHaveLength(4);
+    expect(GIT_CLIENT_PROJECT.locales.en.title).toBe('Strata');
+    expect(GIT_CLIENT_PROJECT.locales.zh.title).toBe('Strata');
     expect(GIT_CLIENT_PROJECT.locales.en.description).toContain('desktop Git client');
     expect(GIT_CLIENT_PROJECT.locales.zh.description).toContain('桌面 Git 客户端');
   });
@@ -32,7 +26,7 @@ describe('GIT_CLIENT_PROJECT', () => {
 
     expect(zh).toMatchObject({
       slug: 'git-client',
-      title: 'Git Client',
+      title: 'Strata',
       order: -10,
       url: 'https://github.com/JadenFanZhupi222/git-client',
     });
@@ -105,8 +99,8 @@ describe('GIT_CLIENT_PROJECT', () => {
 
     await applyFeaturedProjectOrder(payload);
 
-    expect(
-      updates.map(({ data }) => (data as { order: number }).order)
-    ).toEqual([-20, -15, -10, 1]);
+    expect(updates.map(({ data }) => (data as { order: number }).order)).toEqual([
+      -20, -15, -10, 1,
+    ]);
   });
 });

--- a/src/lib/project/gitClientProject.ts
+++ b/src/lib/project/gitClientProject.ts
@@ -21,25 +21,25 @@ export const GIT_CLIENT_PROJECT: GitClientProjectDefinition = {
   tags: ['Tauri 2', 'Rust', 'React 19', 'TypeScript', 'Git'],
   locales: {
     en: {
-      title: 'Git Client',
+      title: 'Strata',
       description:
-        'A cross-platform desktop Git client built for real development workflows with Tauri 2, React 19, and a multi-crate Rust workspace.',
+        'Strata is a cross-platform desktop Git client for everyday development workflows, built with Tauri 2, React 19, and a layered Rust workspace.',
       highlights: [
         'Covers staging, commits, branches, remotes, stash, tags, rebase, reflog, blame, and history search.',
+        'Uses a compact, responsive three-pane interface to keep history search, commit details, and diffs readable across window sizes.',
         'Uses layered Rust crates and typed IPC to separate domain logic, Git backends, application services, and desktop adapters.',
-        'Includes side-by-side and word-level diffs, syntax highlighting, image diffs, and a three-pane conflict editor.',
-        'Hardened with frontend and Rust tests, desktop E2E coverage, cross-platform CI, CSP, and release checks.',
+        'Includes side-by-side and word-level diffs, syntax highlighting, image diffs, and a three-pane conflict editor, backed by cross-platform CI and desktop E2E coverage.',
       ],
     },
     zh: {
-      title: 'Git Client',
+      title: 'Strata',
       description:
-        '一款面向真实开发工作流的跨平台桌面 Git 客户端，基于 Tauri 2、React 19 与 Rust 多 crate 工作区构建。',
+        'Strata 是一款面向日常开发工作流的跨平台桌面 Git 客户端，基于 Tauri 2、React 19 和分层 Rust 工作区构建。',
       highlights: [
         '覆盖暂存、提交、分支、远程仓库、Stash、Tag、Rebase、Reflog、Blame 与历史检索。',
+        '采用紧凑且响应式的三栏界面，让历史搜索、提交详情与 Diff 在不同窗口尺寸下保持清晰。',
         '通过 Rust 分层 crate 与类型化 IPC 隔离领域逻辑、Git 后端、应用服务和桌面适配层。',
-        '支持并排及词级 Diff、语法高亮、图片差异对比和三栏冲突编辑器。',
-        '具备前端与 Rust 测试、桌面端 E2E、跨平台 CI、CSP 和发布检查。',
+        '支持并排及词级 Diff、语法高亮、图片差异对比和三栏冲突编辑器，并由跨平台 CI 与桌面 E2E 覆盖。',
       ],
     },
   },

--- a/src/lib/translations/server.test.ts
+++ b/src/lib/translations/server.test.ts
@@ -42,12 +42,16 @@ describe('getTranslations', () => {
   });
 
   it('uses the same featured project order in both welcome locales', () => {
-    expect(
-      getTranslations('en').welcome.projects.items.map((project) => project.title)
-    ).toEqual(['AI Photo Booth', 'Git Client', 'Family Meal Planner']);
-    expect(
-      getTranslations('zh').welcome.projects.items.map((project) => project.title)
-    ).toEqual(['AI 拍照亭桌面应用', 'Git Client', '家庭食谱小程序']);
+    expect(getTranslations('en').welcome.projects.items.map((project) => project.title)).toEqual([
+      'AI Photo Booth',
+      'Strata',
+      'Family Meal Planner',
+    ]);
+    expect(getTranslations('zh').welcome.projects.items.map((project) => project.title)).toEqual([
+      'AI 拍照亭桌面应用',
+      'Strata',
+      '家庭食谱小程序',
+    ]);
   });
 
   it('keeps Welcome contact actions limited to GitHub and email', () => {


### PR DESCRIPTION
## Summary

- rename the public Git client portfolio title to Strata
- refresh the English and Chinese project copy with the responsive history, details, and diff layout
- update static fallback translations and related tests
- preserve the existing `git-client` slug and repository URL for link and CMS stability

## Validation

- `node node_modules/typescript/bin/tsc --noEmit`
- `node node_modules/vitest/vitest.mjs run src/lib/project/gitClientProject.test.ts src/lib/translations/server.test.ts src/components/home/ProjectArtwork.test.tsx`
- `node node_modules/prettier/bin/prettier.cjs --check ...`
- Payload CMS upsert completed and verified for English and Chinese locales
